### PR TITLE
Adjusted Ingress definition to new API version

### DIFF
--- a/src/networking/ingress.md
+++ b/src/networking/ingress.md
@@ -59,7 +59,7 @@ If you receive an empty output, you might have to wait a little bit longer for I
 Here is the YAML definition of our Ingress resource
 
 ```jsx
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: react-application
@@ -72,9 +72,12 @@ spec:
   - http:
       paths:
       - path: /demo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: react-application
-          servicePort: 8080
+          service:
+            name: react-application
+            port:
+              number: 8080
 ```
 
 - The annotation section is used to provide additional information to the Ingress controller.


### PR DESCRIPTION
I'm currently reading through your web resources and trying out some of the snippets. The `Ingress` K8s resource type apparently needs a new `apiVersion` now, along with some other slightly different configuration options. I fixed the code snippet in the regarding chapter.