### PR TITLE
fix: typo in url to prometheus.md

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -44,7 +44,7 @@
 - [Linkerd](./tools/linkerd.md)
 
 # Observability
-- [Prometheus](./observaility/prometheus.md)
+- [Prometheus](./observability/prometheus.md)
 - [Prometheus Exporter](./observability/prometheus-exporter.md)
 
 # Advanced Topics


### PR DESCRIPTION
Fix typo in the link to prometheus page.

Signed-off-by: Hoang Thanh VO <111461555+ht-vo@users.noreply.github.com>