### PR TITLE
Fix: ServiceMonitor is enabled

### DIFF
--- a/src/observability/prometheus-exporter.md
+++ b/src/observability/prometheus-exporter.md
@@ -140,6 +140,7 @@ mongodb:
   uri: "mongodb://mongodb-service:27017"
 
 serviceMonitor:
+  enabled: true
   additionalLabels:
     release: prometheus
 ```


### PR DESCRIPTION
ServiceMonitor has been disabled as stated in the https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-mongodb-exporter:

 "The servicemonitor has been disabled by default as prometheus operator might not be installed in cluster." ->     https://github.com/prometheus-community/helm-charts/blob/046897216345b83a5cca148448a9e1f374ab1a17/charts/prometheus-mongodb-exporter/values.yaml#L95

That's why we need to enable it for this example otherwise prometheus cannot able to show mongodb exporter target.